### PR TITLE
Allow for Multiline tags

### DIFF
--- a/configurations/default/definedTags.js
+++ b/configurations/default/definedTags.js
@@ -29,7 +29,7 @@ var definedTags = (function() {
         /**
          * Method tag parser.
          * @param  {Array} words Documentation line, split on spaces.
-         * @expects words  [@method', 'functionName']
+         * @expects words  ['@method', 'functionName']
          * @return {docob} docob Docob (real descriptive, I know, TODO).
          */
         'method': function(words) {
@@ -40,7 +40,7 @@ var definedTags = (function() {
         /**
          * Module tag parser.
          * @param  {Array} words Documentation line, split on spaces.
-         * @expects words  [@module', 'moduleName']
+         * @expects words  ['@module', 'moduleName']
          * @return {docob} docob Docob (real descriptive, I know, TODO).
          */
         'module': function(words) {
@@ -51,7 +51,7 @@ var definedTags = (function() {
         /**
          * Param tag parser.
          * @param  {Array} words Documentation line, split on spaces.
-         * @expects words  [@param', '{Type}', 'paramName', 'Description', 'goes', 'here', ...]
+         * @expects words  ['@param', '{Type}', 'paramName', 'Description', 'goes', 'here', ...]
          * @return {docob} docob Docob (real descriptive, I know, TODO).
          */
         'param': function(words, tagType) {
@@ -66,7 +66,7 @@ var definedTags = (function() {
         /**
          * Return tag parser.
          * @param  {Array} words Documentation line, split on spaces.
-         * @expects words  [@returns', '{Type}', 'returnName', 'Description', 'goes', 'here', ...]
+         * @expects words  ['@returns', '{Type}', 'returnName', 'Description', 'goes', 'here', ...]
          * @return {docob} docob Docob (real descriptive, I know, TODO).
          */
         'returns': function(words) {

--- a/configurations/default/definedTags.js
+++ b/configurations/default/definedTags.js
@@ -29,52 +29,52 @@ var definedTags = (function() {
         /**
          * Method tag parser.
          * @param  {Array} words Documentation line, split on spaces.
-         * @expects words  ['*', '@method', 'functionName']
+         * @expects words  [@method', 'functionName']
          * @return {docob} docob Docob (real descriptive, I know, TODO).
          */
         'method': function(words) {
             var tagType = 'function';
-            var name = words[2];
+            var name = words[1];
             return new docob(tagType, name);
         },
         /**
          * Module tag parser.
          * @param  {Array} words Documentation line, split on spaces.
-         * @expects words  ['*', '@module', 'moduleName']
+         * @expects words  [@module', 'moduleName']
          * @return {docob} docob Docob (real descriptive, I know, TODO).
          */
         'module': function(words) {
             var tagType = 'module';
-            var name = words[2];
+            var name = words[1];
             return new docob(tagType, name);
         },
         /**
          * Param tag parser.
          * @param  {Array} words Documentation line, split on spaces.
-         * @expects words  ['*', '@param', '{Type}', 'paramName', 'Description', 'goes', 'here', ...]
+         * @expects words  [@param', '{Type}', 'paramName', 'Description', 'goes', 'here', ...]
          * @return {docob} docob Docob (real descriptive, I know, TODO).
          */
         'param': function(words, tagType) {
             var tagType = 'param';
-            var name = words[3];
+            var name = words[2];
             var innards = {
-                type: words[2].substring(1, words[2].length - 1),
-                desc: words.splice(4).join(" ")
+                type: words[1].substring(1, words[1].length - 1),
+                desc: words.splice(3).join(" ")
             };
             return new docob(tagType, name, innards);
         },
         /**
          * Return tag parser.
          * @param  {Array} words Documentation line, split on spaces.
-         * @expects words  ['*', '@returns', '{Type}', 'returnName', 'Description', 'goes', 'here', ...]
+         * @expects words  [@returns', '{Type}', 'returnName', 'Description', 'goes', 'here', ...]
          * @return {docob} docob Docob (real descriptive, I know, TODO).
          */
         'returns': function(words) {
             var tagType = 'return';
-            var name = words[3];
+            var name = words[2];
             var innards = {
-                returnType: words[2].substring(1, words[2].length - 1),
-                desc: words.splice(4).join(" ")
+                returnType: words[1].substring(1, words[1].length - 1),
+                desc: words.splice(3).join(" ")
             };
             return new docob(tagType, name, innards);
         }

--- a/parser.js
+++ b/parser.js
@@ -13,12 +13,10 @@ var newparser = (function() {
 
         /**
          * TODO:
-         * 	- Multi-line tag support.
          * 	- Configurify everything.
          * 	- Error support.
          * 	- Read file line by line?
          * 		- For line number.
-         * 		- Easier multi-line tags.
          */
 
         var textBlocks = findBlocks(file);

--- a/parser.js
+++ b/parser.js
@@ -24,6 +24,7 @@ var newparser = (function() {
         var textBlocks = findBlocks(file);
         var objectBlocks = [];
         textBlocks.forEach(function(textBlock) {
+            textBlock = removePrefixes(textBlock);
             objectBlocks.push(convertToObject(textBlock));
         });
 
@@ -49,6 +50,30 @@ var newparser = (function() {
     };
 
     /**
+     * Removes the line prefix from every line of a text block.
+     *
+     * @method removePrefixes
+     * @param  {String} textBlock Block of text to act on.
+     * @return {String} Block of text, without prefixes.
+     */
+    function removePrefixes(textBlock) {
+        var linePrefix = '*'; // TODO: Configurify prefix.
+        var textLines = splitTextBlock(textBlock);
+        // Loop over every line and remove the prefix if there is one.
+        for(var i = 0; i < textLines.length; i++) {
+            textLines[i] = textLines[i].trim();
+            if(textLines[i].indexOf(linePrefix) === 0) {
+                textLines[i] = textLines[i].substring(1).trim();
+            }
+        }
+        return joinTextLines(textLines);
+    }
+
+    function separateTags(textBlock) {
+        // TODO: This.
+    }
+
+    /**
      * Converts a block of text into a single object.
      * @param  {String} textBlock Documentation text block.
      * @return {Object} Documentation object.
@@ -62,13 +87,13 @@ var newparser = (function() {
             var words = textLine.split(' ');
 
             // The tag word starts with an @
-            if(!words[1] || words[1].indexOf('@') !== 0) {
+            if(!words[0] || words[0].indexOf('@') !== 0) {
                 // Error; not a tag.
                 // return null; //WORD_NOT_A_TAG
                 return;
             }
 
-            var tagType = words[1].substring(1);
+            var tagType = words[0].substring(1);
             var tagFunction = TAG_LIST[tagType];
 
             // A parsing function should have been defined.
@@ -128,6 +153,16 @@ var newparser = (function() {
      */
     function splitTextBlock(textBlock) {
         return textBlock.split('\n');
+    }
+
+    /**
+     * Utility function to join text lines into a text block.
+     * Meant as an inverse function to splitTextBlock.
+     * @param  {Array} textLines Array of strings to join.
+     * @return {String} Text block.
+     */
+    function joinTextLines(textLines) {
+        return textLines.join('\n');
     }
 
     /**

--- a/test/otherfile.js
+++ b/test/otherfile.js
@@ -11,7 +11,8 @@ function iDoStuff() {
 /**
  * Something something documentation.
  * @method something
- * @param {Nothing} nothing Really, it's nothing.
+ * @param {Nothing} nothing Really, it's nothing. Seriously,
+ * it returns so much nothing this is a multi-line tag line.
  */
 function something(nothing) {
 


### PR DESCRIPTION
Now does extra processing on a textblock. 
- Removes prefixes from each line, e.g. /**, *, */.
- Splits textblock by tags, rather than simply by newlines.
